### PR TITLE
✨feat: trend,like redis 캐싱 적용

### DIFF
--- a/src/main/java/org/example/vibelist/domain/explore/controller/ExploreController.java
+++ b/src/main/java/org/example/vibelist/domain/explore/controller/ExploreController.java
@@ -50,7 +50,7 @@ public class ExploreController {
     public ResponseEntity<List<TrendResponse>> getTrends(
             @Parameter(description = "최대 조회 개수", example = "10")
             @RequestParam(defaultValue = "10") int limit) {
-        List<TrendResponse> trends = trendService.getTopTrends(limit);
+        List<TrendResponse> trends = trendService.getTopTrendsWithRedis(limit);
         return ResponseEntity.ok(trends);
     }
 }

--- a/src/main/java/org/example/vibelist/domain/explore/pool/TrendPoolProvider.java
+++ b/src/main/java/org/example/vibelist/domain/explore/pool/TrendPoolProvider.java
@@ -1,0 +1,57 @@
+package org.example.vibelist.domain.explore.pool;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.vibelist.domain.explore.dto.TrendResponse;
+import org.example.vibelist.global.redis.RedisUtil;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TrendPoolProvider {
+    private final RedisUtil redisUtil;
+    private static final String DEFAULT_POOL_KEY = "trend:pool";
+    private static final long DEFAULT_TTL = 60 * 65; // 1시간 5분
+
+    // Pool 저장 (기본키)
+    public void savePool(List<TrendResponse> pool) {
+        savePool(DEFAULT_POOL_KEY, pool, DEFAULT_TTL, TimeUnit.SECONDS);
+    }
+
+    // Pool 저장 (커스텀 키/TTL)
+    public void savePool(String key, List<TrendResponse> pool, long ttl, TimeUnit unit) {
+        redisUtil.set(key, pool, ttl, unit);
+    }
+
+    // Pool 조회 (기본키)
+    @SuppressWarnings("unchecked")
+    public List<TrendResponse> getPool() {
+        return (List<TrendResponse>) redisUtil.get(DEFAULT_POOL_KEY);
+    }
+
+    // Pool 조회 (커스텀 키)
+    @SuppressWarnings("unchecked")
+    public List<TrendResponse> getPool(String key) {
+        return (List<TrendResponse>) redisUtil.get(key);
+    }
+
+    // Pool 삭제
+    public void deletePool() {
+        redisUtil.delete(DEFAULT_POOL_KEY);
+    }
+    public void deletePool(String key) {
+        redisUtil.delete(key);
+    }
+
+    // Pool 업데이트 (있으면 덮어씀)
+    public void updatePool(List<TrendResponse> pool) {
+        savePool(pool);
+    }
+    public void updatePool(String key, List<TrendResponse> pool, long ttl, TimeUnit unit) {
+        savePool(key, pool, ttl, unit);
+    }
+}

--- a/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEvent.java
+++ b/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEvent.java
@@ -1,0 +1,24 @@
+package org.example.vibelist.domain.post.like.pool;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 좋아요/취소 이벤트 (Redis 버퍼용)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeEvent implements Serializable {
+    private Long postId;
+    private Long userId;
+    private Action action; // LIKE or UNLIKE
+    private long timestamp;
+
+    public enum Action {
+        LIKE, UNLIKE
+    }
+} 

--- a/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEventPoolBatchScheduler.java
+++ b/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEventPoolBatchScheduler.java
@@ -1,0 +1,71 @@
+package org.example.vibelist.domain.post.like.pool;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.vibelist.domain.post.entity.Post;
+import org.example.vibelist.domain.post.like.entity.PostLike;
+import org.example.vibelist.domain.post.like.repository.PostLikeRepository;
+import org.example.vibelist.domain.post.repository.PostRepository;
+import org.example.vibelist.domain.user.repository.UserRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeEventPoolBatchScheduler {
+    private final LikeEventPoolBufferProvider bufferProvider;
+    private final PostLikeRepository postLikeRepo;
+    private final PostRepository postRepo;
+    private final UserRepository userRepo;
+
+    /**
+     * 3분마다 파티션별로 좋아요 이벤트를 일괄 DB 반영
+     */
+    @Scheduled(cron = "0 */3 * * * ?")
+    @Transactional
+    public void batchApplyLikeEvents() {
+        int partitionCount = bufferProvider.getPartitionCount();
+        for (int partition = 0; partition < partitionCount; partition++) {
+            List<LikeEvent> events = bufferProvider.getEvents(partition);
+            if (events.isEmpty()) continue;
+            log.info("[LikeBatch] Partition {}: {} events to process", partition, events.size());
+            // postId-userId별 최신 이벤트만 남김
+            Map<String, LikeEvent> latest = new HashMap<>();
+            for (LikeEvent e : events) {
+                String key = e.getPostId() + ":" + e.getUserId();
+                LikeEvent prev = latest.get(key);
+                if (prev == null || e.getTimestamp() > prev.getTimestamp()) {
+                    latest.put(key, e);
+                }
+            }
+            // 최신 이벤트만 DB에 반영
+            for (LikeEvent e : latest.values()) {
+                try {
+                    if (e.getAction() == LikeEvent.Action.LIKE) {
+                        if (!postLikeRepo.existsByPostIdAndUserId(e.getPostId(), e.getUserId())) {
+                            Post post = postRepo.findById(e.getPostId()).orElse(null);
+                            if (post != null) {
+                                PostLike like = PostLike.create(userRepo.getReferenceById(e.getUserId()), post);
+                                postLikeRepo.save(like);
+                                post.incLike();
+                            }
+                        }
+                    } else if (e.getAction() == LikeEvent.Action.UNLIKE) {
+                        if (postLikeRepo.existsByPostIdAndUserId(e.getPostId(), e.getUserId())) {
+                            postLikeRepo.deleteByPostIdAndUserId(e.getPostId(), e.getUserId());
+                            postRepo.findById(e.getPostId()).ifPresent(Post::decLike);
+                        }
+                    }
+                } catch (Exception ex) {
+                    log.error("[LikeBatch] Failed to apply event: {}", e, ex);
+                }
+            }
+            // 처리 후 버퍼 삭제
+            bufferProvider.clearBuffer(partition);
+        }
+    }
+} 

--- a/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEventPoolBufferProvider.java
+++ b/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEventPoolBufferProvider.java
@@ -1,0 +1,69 @@
+package org.example.vibelist.domain.post.like.pool;
+
+import lombok.RequiredArgsConstructor;
+import org.example.vibelist.global.redis.RedisUtil;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 파티션별 좋아요 이벤트 버퍼 Provider (Redis)
+ */
+@Component
+@RequiredArgsConstructor
+public class LikeEventPoolBufferProvider {
+    private static final int PARTITION_COUNT = 10;
+    private static final String BUFFER_KEY_PREFIX = "like:buffer:";
+
+    private final RedisUtil redisUtil;
+
+    // 파티션 계산
+    public int getPartition(Long postId) {
+        return (int) (postId % PARTITION_COUNT);
+    }
+
+    // 버퍼에 이벤트 추가
+    public void addEvent(LikeEvent event) {
+        int partition = getPartition(event.getPostId());
+        String key = BUFFER_KEY_PREFIX + partition;
+        List<LikeEvent> buffer = (List<LikeEvent>) redisUtil.get(key);
+        if (buffer == null) buffer = new ArrayList<>();
+        buffer.add(event);
+        redisUtil.set(key, buffer);
+    }
+
+    // 파티션별 버퍼 조회
+    @SuppressWarnings("unchecked")
+    public List<LikeEvent> getEvents(int partition) {
+        String key = BUFFER_KEY_PREFIX + partition;
+        List<LikeEvent> buffer = (List<LikeEvent>) redisUtil.get(key);
+        return buffer != null ? buffer : new ArrayList<>();
+    }
+
+    // 파티션별 버퍼 삭제
+    public void clearBuffer(int partition) {
+        String key = BUFFER_KEY_PREFIX + partition;
+        redisUtil.delete(key);
+    }
+
+    // 전체 파티션 개수 반환
+    public int getPartitionCount() {
+        return PARTITION_COUNT;
+    }
+
+    // 특정 postId/userId의 최신 이벤트 조회
+    public LikeEvent getLatestEventForUser(Long postId, Long userId) {
+        int partition = getPartition(postId);
+        List<LikeEvent> buffer = getEvents(partition);
+        LikeEvent latest = null;
+        for (LikeEvent e : buffer) {
+            if (e.getPostId().equals(postId) && e.getUserId().equals(userId)) {
+                if (latest == null || e.getTimestamp() > latest.getTimestamp()) {
+                    latest = e;
+                }
+            }
+        }
+        return latest;
+    }
+} 


### PR DESCRIPTION


## 1. 트렌드(Trend) Pool 캐싱

### 활용 로직 요약
- **목적:** 트렌드 리스트를 Redis에 캐싱하여 빠른 조회와 DB 부하 감소
- **동작 방식:**
  - 트렌드 조회 API는 Redis(trend:pool)에서 먼저 조회, 없으면 DB에서 조회 후 Redis에 저장(1시간 TTL)
  - 스케쥴러가 트렌드 계산 후 최신 리스트를 Redis에 갱신

### 시퀀스 다이어그램
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Redis
    participant Scheduler
    participant DB

    %% --- 트렌드 Pool 캐싱 ---
    Note over API,Redis: [트렌드 조회]
    Client->>API: GET /explore/trend
    API->>Redis: trend:pool 조회
    alt Pool 있음
        Redis-->>API: 트렌드 리스트 반환
    else Pool 없음
        API->>DB: 트렌드 DB 조회
        DB-->>API: 트렌드 리스트
        API->>Redis: trend:pool 저장 (1시간 TTL)
    end
    API-->>Client: 트렌드 리스트 반환

    Note over Scheduler,Redis: [트렌드 Pool 갱신]
    Scheduler->>DB: 트렌드 계산/저장
    Scheduler->>Redis: trend:pool 최신 리스트 저장
```

---

## 2. 좋아요(Like) 비동기 일괄처리

### 활용 로직 요약
- **목적:** 좋아요/취소 요청을 Redis에 임시 저장하여 대량 트래픽에도 DB 부하 없이 일괄 반영
- **동작 방식:**
  - 좋아요 토글 API는 Redis(파티션별 like:buffer:{partition})에 이벤트만 추가, 즉시 OK 응답
  - 3분마다 스케쥴러가 파티션별로 Redis 버퍼를 읽어 최신 이벤트만 DB에 일괄 반영, 처리 후 버퍼 삭제

### 시퀀스 다이어그램
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Redis
    participant Scheduler
    participant DB

    %% --- 좋아요 비동기 일괄처리 ---
    Note over API,Redis: [좋아요 토글]
    Client->>API: POST /like/toggle
    API->>Redis: like:buffer:{partition}에 이벤트 추가
    API-->>Client: OK (즉시 응답)

    Note over Scheduler,Redis: [좋아요 일괄 반영]
    Scheduler->>Redis: 파티션별 버퍼 조회
    Scheduler->>DB: 최신 이벤트만 일괄 반영
    Scheduler->>Redis: 버퍼 삭제
```

