### PR TITLE
✨ feat: post 상세조회 시 캐싱 구현

### DIFF
--- a/src/main/java/org/example/vibelist/domain/post/cache/PostCacheProvider.java
+++ b/src/main/java/org/example/vibelist/domain/post/cache/PostCacheProvider.java
@@ -1,0 +1,65 @@
+package org.example.vibelist.domain.post.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.vibelist.domain.post.dto.PostDetailResponse;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostCacheProvider {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String POST_CACHE_KEY = "post:";
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    public PostDetailResponse get(Long postId) {
+        try {
+            String key = POST_CACHE_KEY + postId;
+            Object cachedObject = redisTemplate.opsForValue().get(key);
+
+            if (cachedObject == null) {
+                return null;
+            }
+
+            // LinkedHashMap을 PostDetailResponse로 안전하게 변환
+            PostDetailResponse cachedPost = objectMapper.convertValue(cachedObject, PostDetailResponse.class);
+
+            if (cachedPost != null) {
+                log.info("캐시에서 포스트 조회: postId={}", postId);
+            }
+
+            return cachedPost;
+        } catch (Exception e) {
+            log.error("캐시 조회 실패: postId={}, error={}", postId, e.getMessage());
+            return null;
+        }
+    }
+
+    public void set(Long postId, PostDetailResponse post) {
+        try {
+            String key = POST_CACHE_KEY + postId;
+            redisTemplate.opsForValue().set(key, post, TTL);
+            log.info("캐시에 포스트 저장: postId={}", postId);
+        } catch (Exception e) {
+            log.error("캐시 저장 실패: postId={}, error={}", postId, e.getMessage());
+        }
+    }
+
+    public void delete(Long postId) {
+        try {
+            String key = POST_CACHE_KEY + postId;
+            redisTemplate.delete(key);
+            log.info("캐시에서 포스트 삭제: postId={}", postId);
+        } catch (Exception e) {
+            log.error("캐시 삭제 실패: postId={}, error={}", postId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/example/vibelist/domain/post/cache/PostCacheService.java
+++ b/src/main/java/org/example/vibelist/domain/post/cache/PostCacheService.java
@@ -1,0 +1,93 @@
+package org.example.vibelist.domain.post.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.vibelist.domain.post.dto.PostDetailResponse;
+import org.example.vibelist.domain.post.like.service.LikeService;
+import org.springframework.stereotype.Service;
+
+/**
+ * 게시글 캐시 관련 로직을 담당하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostCacheService {
+
+    private final PostCacheProvider postCacheProvider;
+    private final LikeService likeService;
+
+    /**
+     * 캐시에서 게시글 조회 (실시간 좋아요 수 반영)
+     */
+    public PostDetailResponse getFromCache(Long postId) {
+        try {
+            PostDetailResponse cachedPost = postCacheProvider.get(postId);
+
+            if (cachedPost == null) {
+                return null; // 캐시 미스
+            }
+
+            // 실시간 좋아요 수 확인 및 반영
+            long currentLikeCount = likeService.countPostLikes(postId);
+
+            if (currentLikeCount != cachedPost.likeCnt()) {
+                // 좋아요 수가 변경된 경우 업데이트된 DTO 생성
+                return new PostDetailResponse(
+                    cachedPost.id(), cachedPost.userId(), cachedPost.userName(),
+                    cachedPost.userProfileName(), cachedPost.content(), cachedPost.tags(),
+                    cachedPost.isPublic(), currentLikeCount, // 실시간 좋아요 수
+                    cachedPost.viewCnt(), cachedPost.createdAt(), cachedPost.updatedAt(),
+                    cachedPost.playlist()
+                );
+            }
+
+            return cachedPost;
+        } catch (Exception e) {
+            log.error("캐시 조회 중 오류 발생: postId={}, error={}", postId, e.getMessage());
+            return null; // fallback to DB
+        }
+    }
+
+    /**
+     * 캐시에 게시글 저장 (공개 게시글만)
+     */
+    public void saveToCache(Long postId, PostDetailResponse post) {
+        if (post.isPublic()) { // 공개 게시글만 캐시
+            postCacheProvider.set(postId, post);
+        }
+    }
+
+    /**
+     * 캐시에서 게시글 삭제
+     */
+    public void deleteFromCache(Long postId) {
+        postCacheProvider.delete(postId);
+    }
+
+    /**
+     * 권한 체크 후 캐시 처리
+     */
+    public PostDetailResponse getWithPermissionCheck(Long postId, Long viewerId) {
+        PostDetailResponse cachedPost = getFromCache(postId);
+
+        if (cachedPost == null) {
+            return null;
+        }
+
+        // 공개 게시글이면 바로 반환
+        if (cachedPost.isPublic()) {
+            return cachedPost;
+        }
+
+        // 비공개 게시글 권한 체크
+        if (viewerId != null && cachedPost.userId().equals(viewerId)) {
+            return cachedPost; // 작성자는 접근 가능
+        }
+
+        // 권한 없으면 캐시 삭제 후 null 반환
+        deleteFromCache(postId);
+        return null;
+    }
+}
+

--- a/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEventPoolBatchScheduler.java
+++ b/src/main/java/org/example/vibelist/domain/post/like/pool/LikeEventPoolBatchScheduler.java
@@ -6,6 +6,7 @@ import org.example.vibelist.domain.post.entity.Post;
 import org.example.vibelist.domain.post.like.entity.PostLike;
 import org.example.vibelist.domain.post.like.repository.PostLikeRepository;
 import org.example.vibelist.domain.post.repository.PostRepository;
+import org.example.vibelist.domain.post.cache.PostCacheService;
 import org.example.vibelist.domain.user.repository.UserRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,6 +22,7 @@ public class LikeEventPoolBatchScheduler {
     private final PostLikeRepository postLikeRepo;
     private final PostRepository postRepo;
     private final UserRepository userRepo;
+    private final PostCacheService postCacheService;
 
     /**
      * 3분마다 파티션별로 좋아요 이벤트를 일괄 DB 반영
@@ -42,9 +44,14 @@ public class LikeEventPoolBatchScheduler {
                     latest.put(key, e);
                 }
             }
+            // 캐시 무효화가 필요한 게시글 ID들을 수집
+            Set<Long> postsToInvalidate = new HashSet<>();
+
             // 최신 이벤트만 DB에 반영
             for (LikeEvent e : latest.values()) {
                 try {
+                    boolean cacheInvalidationNeeded = false;
+
                     if (e.getAction() == LikeEvent.Action.LIKE) {
                         if (!postLikeRepo.existsByPostIdAndUserId(e.getPostId(), e.getUserId())) {
                             Post post = postRepo.findById(e.getPostId()).orElse(null);
@@ -52,20 +59,41 @@ public class LikeEventPoolBatchScheduler {
                                 PostLike like = PostLike.create(userRepo.getReferenceById(e.getUserId()), post);
                                 postLikeRepo.save(like);
                                 post.incLike();
+                                cacheInvalidationNeeded = true;
                             }
                         }
                     } else if (e.getAction() == LikeEvent.Action.UNLIKE) {
                         if (postLikeRepo.existsByPostIdAndUserId(e.getPostId(), e.getUserId())) {
                             postLikeRepo.deleteByPostIdAndUserId(e.getPostId(), e.getUserId());
                             postRepo.findById(e.getPostId()).ifPresent(Post::decLike);
+                            cacheInvalidationNeeded = true;
                         }
+                    }
+
+                    // 실제로 좋아요 수가 변경된 경우에만 캐시 무효화 대상에 추가
+                    if (cacheInvalidationNeeded) {
+                        postsToInvalidate.add(e.getPostId());
                     }
                 } catch (Exception ex) {
                     log.error("[LikeBatch] Failed to apply event: {}", e, ex);
                 }
             }
+
+            // 좋아요 수가 변경된 게시글들의 캐시 무효화
+            for (Long postId : postsToInvalidate) {
+                try {
+                    postCacheService.deleteFromCache(postId);
+                } catch (Exception ex) {
+                    log.error("[LikeBatch] Failed to invalidate cache for postId: {}", postId, ex);
+                }
+            }
+
+            if (!postsToInvalidate.isEmpty()) {
+                log.info("[LikeBatch] Partition {}: Cache invalidated for {} posts", partition, postsToInvalidate.size());
+            }
+
             // 처리 후 버퍼 삭제
             bufferProvider.clearBuffer(partition);
         }
     }
-} 
+}

--- a/src/main/java/org/example/vibelist/global/redis/RedisConfig.java
+++ b/src/main/java/org/example/vibelist/global/redis/RedisConfig.java
@@ -1,5 +1,8 @@
 package org.example.vibelist.global.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -30,9 +33,18 @@ public class RedisConfig {
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory());
+
+        // ObjectMapper 설정으로 LocalDateTime 직렬화 문제 해결
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
         // JSON 직렬화 설정
         template.setKeySerializer(new StringRedisSerializer()); // key = String
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // value = JSON
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)); // value = JSON with JavaTimeModule
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+
         return template;
     }
 }


### PR DESCRIPTION
```
PostService (비즈니스 로직)
    ↓
PostCacheService (캐시 로직 + 권한 체크)
    ↓  
PostCacheProvider (Redis 저장소 추상화)
```
1. 캐시 전략
- TTL 30분
- 게시글 수정, 삭제 시 캐시 삭제

2. 데이터 정합성 보장
- 좋아요 수: 캐시에서 조회
- 조회수: 캐시 히트 시에도 DB에서 증가 처리(기존 로직 사용)
- 배치: 좋아요 배치 처리 시 캐시 무효화

3. Fallback
- 캐시 조회 실패 시 자동으로 DB 조회

closes(#95) 